### PR TITLE
updated email field length

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 class UserRegistrationForm(forms.Form):
     username = forms.CharField(label='Username', max_length=100, min_length=5,
                                widget=forms.TextInput(attrs={'class': 'form-control'}))
-    email = forms.EmailField(label='Email', max_length=20, min_length=5,
+    email = forms.EmailField(label='Email', max_length=35, min_length=5,
                              widget=forms.EmailInput(attrs={'class': 'form-control'}))
     password1 = forms.CharField(label='Password', max_length=50, min_length=5,
                                 widget=forms.PasswordInput(attrs={'class': 'form-control'}))


### PR DESCRIPTION
The user with a long email cannot be able to signup with their email. 
For example, I had a long email. 
otiennosharon@gmail.com,
I could only write up to gmail.
Now any user with a long email can be able to register and vote!