### PR TITLE
Fixing Naming Convention Mistake in User Seeder Function

### DIFF
--- a/seeder.py
+++ b/seeder.py
@@ -13,7 +13,7 @@ def seed_users(num_entries=10, overwrite=False):
     """
     if overwrite:
         print("Overwriting Users")
-        Users.objects.all().delete()
+        User.objects.all().delete() # Fixed naming convention here
     count = 0
     for _ in range(num_entries):
         first_name = fake.first_name()
@@ -34,6 +34,7 @@ def seed_users(num_entries=10, overwrite=False):
             flush=True
         )
     print()
+
 
 
 def seed_polls(num_entries=10, choice_min=2, choice_max=5, overwrite=False):


### PR DESCRIPTION
The seed_users function in the seeder.py file had a mistake in the naming convention for the User model, which was using "Users" instead of "User". This caused an error when attempting to delete all users from the database. The mistake was fixed by changing "Users" to "User" in the appropriate line of code.